### PR TITLE
Updates StackExchange.Redis to Latest Version

### DIFF
--- a/src/NLog.Targets.Redis.Tests/NLog.Targets.Redis.Tests.csproj
+++ b/src/NLog.Targets.Redis.Tests/NLog.Targets.Redis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/NLog.Targets.Redis/NLog.Targets.Redis.csproj
+++ b/src/NLog.Targets.Redis/NLog.Targets.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <Title>NLog Target for Redis</Title>
     <Description>NLog Target for Redis supporting .Net Framework and .Net Standard</Description>
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
@@ -30,12 +30,16 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="NLog" Version="4.0.0" />
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.0.488" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="NLog" Version="4.5.0" />
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.1.605" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.7.4" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
   </ItemGroup>
 
 </Project>

--- a/src/NLog.Targets.Redis/NLog.Targets.Redis.csproj
+++ b/src/NLog.Targets.Redis/NLog.Targets.Redis.csproj
@@ -28,18 +28,9 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="NLog" Version="4.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="NLog" Version="4.5.0" />
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.1.605" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.7.4" />
-    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.28" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The StackExchange.Redis is updated to version 2.1.58, NLog to 4.7.4, and the targets to .NET Framework 4.6.1 and .NETStandard 2.0. The targets had to change due to StackExchange.Redis no longer targeting .NET Framework 4.5 and .NETStandard 1.5.

I wasn't sure what to update the version to for the project.