### PR TITLE
Update readme with default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `<target />` configuration section contains five required fields and one opt
     <add assembly="NLog.Targets.Redis" />
   </extensions>
   <targets>
-    <target xsi:type="Redis" name="redis" host="127.0.0.1" port="3679" db="0" 
+    <target xsi:type="Redis" name="redis" host="127.0.0.1" port="6379" db="0" 
             key="logKey" dataType="list" 
             layout="${date:format=yyyyMMddHHmmss} ${uppercase:${level}} ${message}" />
   </targets>


### PR DESCRIPTION
While you could use other ports of course, the example value looks like the default and that's confusing.

Fixes #30 