### PR TITLE
Updated to StackExchange.Redis ver. 2.2.4 and added net5.0 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The `<target />` configuration section contains five required fields and one opt
 - dataType (optional): The Redis data type that should be used to store the log messages. This can be either `list` or `channel`, defaults to `list`.
 - layout (required): The layout that defines the format of the message to be sent to the Redis target.
 - db (optional): The Redis database id to store the log messages in, if the Redis database type `list` is chosen.
-
+- clientName (optional): The Client name to use for all Redis connections.
+- configurationOptions (optional): Additional configuration options (comma delimited). See [Configuration Options](https://stackexchange.github.io/StackExchange.Redis/Configuration.html)
 
 ## Config File
 
@@ -43,8 +44,6 @@ The `<target />` configuration section contains five required fields and one opt
 </nlog>
 ```
  
-
-
 ## Notes
 
 This is a fork of https://github.com/richclement/NLog.Redis

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-version: 0.0.{build}
-image: Visual Studio 2017
+version: 3.0.0.{build}
+image: Visual Studio 2019
 configuration: Release
 platform: Any CPU
 dotnet_csproj:
@@ -19,7 +19,7 @@ init:
         Update-AppveyorBuild -Version "$tag"
     }
 build_script:
-- ps: dotnet pack src\NLog.Targets.Redis --configuration Release --include-symbols
+- ps: msbuild /t:restore,pack /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:ContinuousIntegrationBuild=true /p:EmbedUntrackedSources=true /p:PublishRepositoryUrl=true /verbosity:minimal
 test_script:
 - ps: dotnet test .\src\NLog.Targets.Redis.Tests\
 

--- a/src/NLog.Targets.Redis.Tests/Mocks/MockRedisConnectionManager.cs
+++ b/src/NLog.Targets.Redis.Tests/Mocks/MockRedisConnectionManager.cs
@@ -5,22 +5,20 @@ namespace NLog.Targets.Redis.Tests.Mocks
     internal class MockRedisConnectionManager : RedisConnectionManager
     {
         private readonly IConnectionMultiplexer _multiplexer;
-        public ConfigurationOptions ConfigurationOptions;
 
-        public MockRedisConnectionManager(string host, int port, int db, string password,
-            IConnectionMultiplexer multiplexer) : base(host, port, db, password)
+        public MockRedisConnectionManager(IConnectionMultiplexer multiplexer, string host, int port, int db, string password = null, string clientName = null, string configurationOptions = null)
+            : base(host, port, db, password, clientName, configurationOptions)
         {
             _multiplexer = multiplexer;
         }
 
-        public MockRedisConnectionManager(string host, int port, int db, string password)
-            : base(host, port, db, password)
+        public MockRedisConnectionManager(string host, int port, int db, string password = null, string clientName = null, string configurationOptions = null)
+            : base(host, port, db, password, clientName, configurationOptions)
         {
         }
 
-        protected override IConnectionMultiplexer CreateConnectionMultiplexer(ConfigurationOptions connectionOptions)
+        protected override IConnectionMultiplexer CreateConnectionMultiplexer()
         {
-            ConfigurationOptions = connectionOptions;
             return _multiplexer;
         }
     }

--- a/src/NLog.Targets.Redis.Tests/Mocks/MockRedisTarget.cs
+++ b/src/NLog.Targets.Redis.Tests/Mocks/MockRedisTarget.cs
@@ -6,6 +6,8 @@ namespace NLog.Targets.Redis.Tests.Mocks
     {
         private readonly IConnectionMultiplexer _connectionMultiplexer;
 
+        public ConfigurationOptions RedisConfiguration { get; private set; }
+
         public MockRedisTarget()
         {
         }
@@ -15,9 +17,11 @@ namespace NLog.Targets.Redis.Tests.Mocks
             _connectionMultiplexer = connectionMultiplexer;
         }
 
-        internal override RedisConnectionManager CreateConnectionManager(string host, int port, int db, string password)
+        internal override RedisConnectionManager CreateConnectionManager(string host, int port, int db, string password, string clientName, string configurationOptions)
         {
-            return new MockRedisConnectionManager(host, port, db, password, _connectionMultiplexer);
+            var connectionManager = new MockRedisConnectionManager(_connectionMultiplexer, host, port, db, password, clientName, configurationOptions);
+            RedisConfiguration = connectionManager.ConfigurationOptions;
+            return connectionManager;
         }
     }
 }

--- a/src/NLog.Targets.Redis.Tests/NLog.Targets.Redis.Tests.csproj
+++ b/src/NLog.Targets.Redis.Tests/NLog.Targets.Redis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="nsubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/NLog.Targets.Redis.Tests/RedisConnectionManagerTests.cs
+++ b/src/NLog.Targets.Redis.Tests/RedisConnectionManagerTests.cs
@@ -15,7 +15,7 @@ namespace NLog.Targets.Redis.Tests
             var port = 1234;
             var db = 0;
 
-            var connectionManager = new MockRedisConnectionManager(host, port, db, null);
+            var connectionManager = new MockRedisConnectionManager(host, port, db);
 
             //Act
             connectionManager.InitializeConnection();
@@ -37,7 +37,7 @@ namespace NLog.Targets.Redis.Tests
             var db = 0;
             var password = "ABCDEFG";
 
-            var connectionManager = new MockRedisConnectionManager(host, port, db, password);
+            var connectionManager = new MockRedisConnectionManager(host, port, db, password: password);
 
             //Act
             connectionManager.InitializeConnection();
@@ -56,7 +56,7 @@ namespace NLog.Targets.Redis.Tests
             var db = 0;
             var password = "";
 
-            var connectionManager = new MockRedisConnectionManager(host, port, db, password);
+            var connectionManager = new MockRedisConnectionManager(host, port, db, password: password);
 
             //Act
             connectionManager.InitializeConnection();
@@ -75,7 +75,7 @@ namespace NLog.Targets.Redis.Tests
 
             var multiplexer = Substitute.For<IConnectionMultiplexer>();
 
-            var connectionManager = new MockRedisConnectionManager(host, port, db, null, multiplexer);
+            var connectionManager = new MockRedisConnectionManager(multiplexer, host, port, db);
 
             //Act
             connectionManager.InitializeConnection();
@@ -94,7 +94,7 @@ namespace NLog.Targets.Redis.Tests
 
             var multiplexer = Substitute.For<IConnectionMultiplexer>();
 
-            var connectionManager = new MockRedisConnectionManager(host, port, db, null, multiplexer);
+            var connectionManager = new MockRedisConnectionManager(multiplexer, host, port, db);
 
             //Act
             Exception ex = Assert.Throws<Exception>(() => connectionManager.GetDatabase());

--- a/src/NLog.Targets.Redis.Tests/RedisTargetTests.cs
+++ b/src/NLog.Targets.Redis.Tests/RedisTargetTests.cs
@@ -12,12 +12,14 @@ namespace NLog.Targets.Redis.Tests
         protected const string RedisHost = "localhost";
         protected const string RedisPort = "6379";
 
-
         [Fact]
         public void RedisTarget_should_configure_with_list_DataType()
         {
             var mock = new MockRedisTarget();
             NLogRedisConfiguration(mock, RedisDataType.List);
+            Assert.Equal(RedisDataType.List, mock.DataType);
+            Assert.Equal(nameof(RedisTargetTests), mock.RedisConfiguration.ClientName);
+            Assert.Single(mock.RedisConfiguration.EndPoints);
         }
 
         [Fact]
@@ -33,6 +35,7 @@ namespace NLog.Targets.Redis.Tests
         {
             var mock = new MockRedisTarget();
             NLogRedisConfiguration(mock, RedisDataType.Channel);
+            Assert.Equal(RedisDataType.Channel, mock.DataType);
         }
 
         [Fact]
@@ -98,6 +101,7 @@ namespace NLog.Targets.Redis.Tests
             {
                 redisTarget.DataType = dataType.Value;
             }
+            redisTarget.ClientName = nameof(RedisTargetTests);
 
             // setup rules
             var rule1 = new LoggingRule("*", LogLevel.Info, redisTarget);

--- a/src/NLog.Targets.Redis.sln
+++ b/src/NLog.Targets.Redis.sln
@@ -1,11 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31613.86
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Targets.Redis", "NLog.Targets.Redis\NLog.Targets.Redis.csproj", "{D30CC839-170F-4B66-A075-A0EB3FA31FC6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Targets.Redis.Tests", "NLog.Targets.Redis.Tests\NLog.Targets.Redis.Tests.csproj", "{6781DE54-6720-4487-9B7C-DD9C54EFF19A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{97207AB9-7BA0-4D4C-B9CE-2E4682D158BA}"
+	ProjectSection(SolutionItems) = preProject
+		..\appveyor.yml = ..\appveyor.yml
+		..\README.md = ..\README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/NLog.Targets.Redis/NLog.Targets.Redis.csproj
+++ b/src/NLog.Targets.Redis/NLog.Targets.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <Title>NLog Target for Redis</Title>
     <Description>NLog Target for Redis supporting .Net Framework and .Net Standard</Description>
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
@@ -9,33 +9,38 @@
     <Authors>Rich Clement,Julian Verdurmen,Morgan Creekmore,Mark Lopez</Authors>
 
     <!--Version is patched by CI-->
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <!--AssemblyVersion only changes are major releases.-->
-    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
 
-    <PackageReleaseNotes>NLog.Redis is now NLog.Targets.Redis</PackageReleaseNotes>
+    <PackageReleaseNotes>
+- Changed from deprecated StackExchange.Redis.StrongName to StackExchange.Redis ver. 2.2.4
+- Added Net5.0 platform support
+- Added support for specifying ClientName
+- Added support for specifying additional ConfigurationOptions (comma-delimited format)
+    </PackageReleaseNotes>
     <PackageTags>NLog;Redis;Log;Logging</PackageTags>
     <PackageProjectUrl>https://github.com/NLog/NLog.Redis</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/NLog/NLog.Redis/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git@github.com:NLog/NLog.Redis.git</RepositoryUrl>
-  </PropertyGroup>
 
-  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../NLog.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net461' ">true</DisableImplicitFrameworkReferences>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="NLog" Version="4.0.0" />
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.0.488" />
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.5.11" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="NLog" Version="4.5.0" />
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.1.605" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <Reference Include="System" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Changed from deprecated StackExchange.Redis.StrongName to StackExchange.Redis ver. 2.2.4
- Added Net5.0 platform support
- Added support for specifying ClientName
- Added support for specifying additional ConfigurationOptions ([comma-delimited format](https://stackexchange.github.io/StackExchange.Redis/Configuration.html))